### PR TITLE
fix(config): unnest the changelog config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: install
-        run: npm install -g pnpm && pnpm install -r
+        run: npm install -g pnpm@5 && pnpm install -r
       - name: test
         run: npm test
 
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npx pnpm install -r
+      - run: npx pnpm@5 install -r
 
       - name: Publish
         run: npm run release

--- a/packages/release-config-core/index.js
+++ b/packages/release-config-core/index.js
@@ -16,6 +16,7 @@ module.exports = {
   , breakingHeaderPattern: constants.BREAKING_HEADER_REGEX
   , headerCorrespondence: ['type', 'scope', 'subject']
   , issuePrefixes: ['#', 'gh-']
+  , changelogTitle: '## Changelog'
   , referenceActions: [
       'close', 'closes', 'closed', 'fix'
     , 'fixes', 'fixed', 'resolve', 'resolves'
@@ -43,9 +44,7 @@ module.exports = {
 , plugins: [
     ['@semantic-release/commit-analyzer', null]
   , ['@semantic-release/release-notes-generator', null]
-  , ['@semantic-release/changelog', {
-      changelogTitle: '## Changelog'
-    }]
+  , ['@semantic-release/changelog', null]
   , ['@semantic-release/npm', null]
   , ['@semantic-release/git', {
       assets: ['package.json', 'CHANGELOG.md', '!**/node_modules/**']

--- a/packages/release-config-core/test/unit/config.js
+++ b/packages/release-config-core/test/unit/config.js
@@ -5,7 +5,7 @@ const config = require('../../index.js')
 const constants = require('../../lib/constants.js')
 
 function sortByType(a, b) {
-  return a < b ? -1 : 1
+  return a.type < b.type ? -1 : 1
 }
 
 test('release-config-logdna', async (t) => {
@@ -20,6 +20,7 @@ test('release-config-logdna', async (t) => {
   , breakingHeaderPattern: constants.BREAKING_HEADER_REGEX
   , headerCorrespondence: ['type', 'scope', 'subject']
   , issuePrefixes: ['#', 'gh-']
+  , changelogTitle: '## Changelog'
   , referenceActions: [
       'close', 'closes', 'closed', 'fix'
     , 'fixes', 'fixed', 'resolve', 'resolves'


### PR DESCRIPTION
Being nested in the plugin config forces the values and is not
changeable in the context of a shareable config