### PR TITLE
feat(config): Support pnpm in git config

### DIFF
--- a/packages/release-config-core/index.js
+++ b/packages/release-config-core/index.js
@@ -47,7 +47,13 @@ module.exports = {
   , ['@semantic-release/changelog', null]
   , ['@semantic-release/npm', null]
   , ['@semantic-release/git', {
-      assets: ['package.json', 'CHANGELOG.md', '!**/node_modules/**']
+      assets: [
+        'package.json'
+      , 'package-lock.json'
+      , 'pnpm-lock.yaml'
+      , 'CHANGELOG.md'
+      , '!**/node_modules/**'
+      ]
     , message: `release: ${year}-${month}-${day}, `
         + 'Version <%= nextRelease.version %> [skip ci]'
     }]


### PR DESCRIPTION
includes pnpm-lock.yaml in the git assets. When a a version is commit,
this will make sure the lock file for pnpm is included