### PR TITLE
fix(core): make sure not to mutate the commit object

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: install
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 24
       - run: npx pnpm@5 install -r
 
       - name: Publish

--- a/packages/release-config-core/lib/commit.js
+++ b/packages/release-config-core/lib/commit.js
@@ -26,11 +26,15 @@ function typeOf(type) {
 }
 
 function transform(commit) {
-  commit.type = typeOf(commit.type)
-  commit.shortHash = commit.hash.substring(0, 7)
-
-  for (const note of commit.notes) {
-    note.title = '**BREAKING CHANGES**'
+  const output = {
+    ...commit
+  , type: typeOf(commit.type)
+  , shortHash: commit.hash.substring(0, 7)
   }
-  return commit
+
+  output.notes = commit.notes.map((note) => {
+    return {...note, title: '**BREAKING CHANGES**'}
+  })
+
+  return output
 }

--- a/packages/release-config-core/package.json
+++ b/packages/release-config-core/package.json
@@ -65,8 +65,8 @@
     ]
   },
   "dependencies": {
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/git": "^9.0.0"
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1"
   },
   "devDependencies": {
     "eslint": "^7.21.0",


### PR DESCRIPTION
newer versions of semantic release will complain if things to to mutate
the commit object during the release process. This update returns a new
object rather than mutating the commit in place