### PR TITLE
fix(ci): update actions permissions for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: install
-        run: npx pnpm@5 install -r
+        run: npx pnpm@10 install -r
       - name: test
         run: npm test
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-      - run: npx pnpm@5 install -r
+      - run: npx pnpm@10 install -r
 
       - name: Publish
         run: npm run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: install
-        run: npm install -g pnpm@5 && pnpm install -r
+        run: npx pnpm@5 install -r
       - name: test
         run: npm test
 
@@ -32,6 +32,11 @@ jobs:
     name: release
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,8 +49,9 @@ jobs:
         run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PACKAGE_LOCK: 'false'
           GIT_AUTHOR_NAME: 'Dependant Bot'
           GIT_AUTHOR_EMAIL: 'release-bot@codedependant.net'
           GIT_COMMITTER_NAME: 'Dependant Bot'
           GIT_COMMITTER_EMAIL: 'release-bot@codedependant.net'
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: 'false'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "nyc": "nyc",
     "test-all": "npx pnpm run --filter={packages/**} -r --if-present test:ci ",
     "preinstall": "./scripts/preinstall.js",
-    "release": "multi-release"
+    "release": "multi-semantic-release"
   },
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
   },
   "homepage": "https://github.com/esatterwhite/semantic-release-tools#readme",
   "devDependencies": {
-    "@codedependant/multi-release": "^1.0.6",
     "@codedependant/release-config-core": "*",
+    "multi-semantic-release": "^3.1.0",
     "nyc": "^15.1.0",
     "tap": "^14.11.0",
     "tap-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "commitlint": "commitlint-codedependant",
     "test": "./scripts/test-ci.sh",
     "nyc": "nyc",
-    "test-all": "pnpm run -r --if-present test:ci --filter={packages}",
+    "test-all": "npx pnpm run --filter={packages/**} -r --if-present test:ci ",
     "preinstall": "./scripts/preinstall.js",
     "release": "multi-release"
   },

--- a/packages/release-config-core/package.json
+++ b/packages/release-config-core/package.json
@@ -65,11 +65,11 @@
     ]
   },
   "dependencies": {
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "eslint": "^7.21.0",
     "eslint-config-codedependant": "^2.1.5",
     "handlebars": "^4.7.7",

--- a/packages/release-config-core/package.json
+++ b/packages/release-config-core/package.json
@@ -66,7 +66,8 @@
   },
   "dependencies": {
     "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/git": "^10.0.1"
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
     "eslint": "^7.21.0",

--- a/packages/release-config-docker/package.json
+++ b/packages/release-config-docker/package.json
@@ -66,7 +66,8 @@
   },
   "dependencies": {
     "@codedependant/release-config-npm": "1.0.4",
-    "@codedependant/semantic-release-docker": "^3.1.0"
+    "@codedependant/semantic-release-docker": "^3.1.0",
+    "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
     "eslint": "^7.21.0",

--- a/packages/release-config-docker/package.json
+++ b/packages/release-config-docker/package.json
@@ -70,6 +70,8 @@
     "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "eslint": "^7.21.0",
     "eslint-config-codedependant": "^2.1.5",
     "handlebars": "^4.7.7",

--- a/packages/release-config-npm/package.json
+++ b/packages/release-config-npm/package.json
@@ -69,6 +69,8 @@
     "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "eslint": "^7.21.0",
     "eslint-config-codedependant": "^2.1.5",
     "handlebars": "^4.7.7",

--- a/packages/release-config-npm/package.json
+++ b/packages/release-config-npm/package.json
@@ -65,7 +65,8 @@
     ]
   },
   "dependencies": {
-    "@codedependant/release-config-core": "1.1.0"
+    "@codedependant/release-config-core": "1.1.0",
+    "@semantic-release/npm": "^13.1.5"
   },
   "devDependencies": {
     "eslint": "^7.21.0",


### PR DESCRIPTION
Include permissions on transient github tokens for publishing workflows.
Removes the NPM_TOKEN env var as that should be dynamically generated
via npms OIDC workflow and trusted publishing